### PR TITLE
Fix title patterns to not use unsupported proc

### DIFF
--- a/lib/puppet/type/windows_env.rb
+++ b/lib/puppet/type/windows_env.rb
@@ -29,8 +29,8 @@ Puppet::Type.newtype(:windows_env) do
   # the variable name (for deletion purposes, say, or to provide an array),
   # so value will be set to nil (and possibly overridden later).
   def self.title_patterns
-    [[%r{^(.*?)=(.*)$}, [[:variable, proc { |x| x }], [:value, proc { |x| x }]]],
-     [%r{^([^=]+)$}, [[:variable, proc { |x| x }]]]]
+    [[%r{^(.*?)=(.*)$}, [[:variable], [:value]]],
+     [%r{^([^=]+)$}, [[:variable]]]]
   end
 
   ensurable do

--- a/spec/unit/puppet/type/windows_env_type_spec.rb
+++ b/spec/unit/puppet/type/windows_env_type_spec.rb
@@ -8,6 +8,23 @@ describe Puppet::Type.type(:windows_env) do
     expect(type.key_attributes).to eq(keyattribute)
   end
 
+  describe 'title' do
+    it 'sets title to variable' do
+      windows_env = described_class.new(title: 'PATH', value: 'C:\code\bin')
+      expect(windows_env[:variable]).to eq('PATH')
+    end
+
+    it 'sets componsite title to variable' do
+      windows_env = described_class.new(title: 'PATH=C:\code\bin')
+      expect(windows_env[:variable]).to eq('PATH')
+    end
+
+    it 'sets componsite title to value' do
+      windows_env = described_class.new(title: 'PATH=C:\code\bin')
+      expect(windows_env[:value]).to eq(['C:\code\bin'])
+    end
+  end
+
   describe 'when validating attributes' do
     params = [
       :variable,


### PR DESCRIPTION
This change will allow `puppet generate types` to function

Error:
```
Error: /etc/puppetlabs/code/environments/production/modules/windows_env/lib/puppet/type/windows_env.rb: title patterns that use procs are not supported.
```

https://tickets.puppetlabs.com/browse/MODULES-4505?focusedCommentId=418416&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-418416
https://github.com/treydock/puppet-module-keycloak/pull/21

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
