### PR TITLE
(FACT-1346) Add default Windows facts as a custom fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,47 @@ or refresh their environment by some other means.
       subscribe   => Windows_env['KOOLVAR'],
       refreshonly => true,
     }
+```
 
+## Facts
+
+### `windows_env`
+
+A structured fact which lists the following Windows environment variables
+
+- ALLUSERSPROFILE
+- APPDATA
+- COMMONPROGRAMFILES
+- COMMONPROGRAMFILES(X86)
+- HOME
+- HOMEDRIVE
+- HOMEPATH
+- LOCALAPPDATA
+- PATHEXT
+- PROCESSOR_IDENTIFIER
+- PROCESSOR_LEVEL
+- PROCESSOR_REVISION
+- PROGRAMDATA
+- PROGRAMFILES
+- PROGRAMFILES(X86)
+- PSMODULEPATH
+- PUBLIC
+- SYSTEMDRIVE
+- SYSTEMROOT
+- TEMP
+- TMP
+- USERPROFILE
+- WINDIR
+
+Note that the names will appear as uppercase in the fact, for example the `windir` environment variable will appears as `WINDIR` in the fact
+
+### Examples
+
+```puppet
+    $app_data = $facts['windows_env']['APPDATA']
+
+    # Output the AppData path in the puppet log
+    notify { $app_data: }
 ```
 
 ## Acknowledgements

--- a/lib/facter/windows_env.rb
+++ b/lib/facter/windows_env.rb
@@ -1,0 +1,40 @@
+Facter.add('windows_env') do
+  confine osfamily: :windows
+  setcode do
+    require 'puppet/util/windows/process'
+
+    # This list must be in uppercase
+    whitelist = %w[
+      ALLUSERSPROFILE
+      APPDATA
+      COMMONPROGRAMFILES
+      COMMONPROGRAMFILES(X86)
+      HOME
+      HOMEDRIVE
+      HOMEPATH
+      LOCALAPPDATA
+      PATHEXT
+      PROCESSOR_IDENTIFIER
+      PROCESSOR_LEVEL
+      PROCESSOR_REVISION
+      PROGRAMDATA
+      PROGRAMFILES
+      PROGRAMFILES(X86)
+      PSMODULEPATH
+      PUBLIC
+      SYSTEMDRIVE
+      SYSTEMROOT
+      TEMP
+      TMP
+      USERPROFILE
+      WINDIR
+    ]
+
+    result = {}
+    env_hash = Puppet::Util::Windows::Process.get_environment_strings
+    env_hash.keys.
+      select { |key| whitelist.include?(key.upcase) }.
+      each { |key| result[key.upcase] = env_hash[key] }
+    result
+  end
+end


### PR DESCRIPTION
Previously facter doesn't expose default Windows environment variables such as
windir or APPDATA.  This commit adds a custom structured fact which exposes a
whitelisted set of windows environment variables which can be easily consumed in
manifests.  Note that the environment name is purposely uppercased as Windows
env. vars are not case sensitive and it makes it easier to author Puppet
manifests if we're not constantly checking; is TMP or tmp or Tmp.

The custom facts can be accessed via the $facts hash e.g.
$appdata = $facts['windows_env']['APPDATA'].