### PR TITLE
Fix: Could not set 'present' on ensure: uninitialized constant Win32::Registry::KEY_WOW64_64KEY

### DIFF
--- a/lib/puppet/provider/windows_env/windows_env.rb
+++ b/lib/puppet/provider/windows_env/windows_env.rb
@@ -7,7 +7,7 @@ if Puppet.features.microsoft_windows?
   require 'win32/registry'
   module Win32
     class Registry
-      KEY_WOW64_64KEY = 0x0100 unless defined?(KEY_WOW64_64KEY)
+      KEY_WOW64_64KEY = 0x0100
     end
   end
 end


### PR DESCRIPTION
 Removed Reg key check.

<!--

Thank you for contributing to this project!

 

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/

- Please check that here is no existing issue or PR that addresses your problem.

- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

 

-->

#### Pull Request (PR) description

<!--

Line 10, windows_env.rb, the snippet "unless defined?(KEY_WOW64_64KEY)" is causing the issue. When the `defined?` function tries to determine if the `KEY_WOW64_64KEY` constance is already initialized, in my environment the answer is coming back as "yes". Hence the module doesn't bother to reinitialize. However, the thing it would have reinitialized is not just `KEY_WOW64_64KEY` in the top scope, but a namespaced copy in `Win32::Registry::KEY_WOW64_64KEY`. Then, when the module tries to access `Win32::Registry::KEY_WOW64_64KEY` later in the code at line 290, the call fails because the new constant was not defined, because the top scope  `KEY_WOW64_64KEY` already exists. This is why the error message is asking if you really wanted to access the top scope copy, because that one already exists.

-->

 

#### This Pull Request (PR) fixes the following issues

<!--

This pull request fixes the following error:

Fixes error message:
"Error: Could not set 'present' on ensure: uninitialized constant Win32::Registry::KEY_WOW64_64KEY
Did you mean?  KEY_WOW64_64KEY (file: /etc/puppetlabs/code/environments/production/xxx, line: 2)"

-->
